### PR TITLE
Implement lean-core IE runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # ief
+
+Runtime components and data structures that implement the Lean-Core Information Extraction (IE) pipeline spec.  See `spec_v_0.md` for the authoritative contract; the Python package in `ief/` provides:
+
+- Typed artifact models (documents, text/layout layers, spans, mentions, key-value pairs, relations).
+- Task base classes with schema-aware parameter validation and provenance recording.
+- A capability-based registry plus a DAG pipeline orchestrator with typed ports.
+
+```python
+from ief import Pipeline, TaskRegistry
+
+registry = TaskRegistry()
+# register concrete tasks ...
+
+config = {
+    "version": "0.1",
+    "pipeline": {
+        "nodes": [
+            {"id": "ingest", "uses": "ie.ingest.text/mock"},
+        ],
+        "edges": [],
+    },
+}
+
+pipeline = Pipeline.from_config_dict(config, registry)
+run = pipeline.run()
+print(run.metrics)
+```

--- a/ief/__init__.py
+++ b/ief/__init__.py
@@ -1,0 +1,54 @@
+"""Core runtime components for the Lean-Core Information Extraction pipeline.
+
+This package provides Python building blocks that follow the contracts laid out
+in ``spec_v_0.md``.  The goal is to make it straightforward to wire together
+typed tasks inside a DAG, while keeping artifacts and provenance traceable.
+"""
+
+from .artifacts import (
+    Artifact,
+    BoundingBox,
+    Document,
+    DocumentSource,
+    EntityMention,
+    KVPair,
+    LayoutElement,
+    LayoutLayer,
+    PageBox,
+    PageGeometry,
+    Relation,
+    RelationArgument,
+    SpanRef,
+    TextLayer,
+    TextToken,
+)
+from .pipeline import Pipeline, PipelineConfig, PipelineNode, PipelineEdge, PipelineRunResult
+from .registry import TaskRegistry
+from .tasks import RunContext, Task, TaskResult
+from .trace import Trace
+
+__all__ = [
+    "Artifact",
+    "BoundingBox",
+    "Document",
+    "DocumentSource",
+    "EntityMention",
+    "KVPair",
+    "LayoutElement",
+    "LayoutLayer",
+    "PageBox",
+    "PageGeometry",
+    "Pipeline",
+    "PipelineConfig",
+    "PipelineEdge",
+    "PipelineNode",
+    "PipelineRunResult",
+    "RunContext",
+    "SpanRef",
+    "Task",
+    "TaskRegistry",
+    "TaskResult",
+    "TextLayer",
+    "TextToken",
+    "Trace",
+]

--- a/ief/artifacts.py
+++ b/ief/artifacts.py
@@ -1,0 +1,203 @@
+"""Artifact data structures used throughout the IE pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, Iterable, List, Mapping, MutableMapping, Tuple
+
+from .trace import Trace
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """Axis-aligned bounding box."""
+
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    def width(self) -> float:
+        return max(0.0, self.x1 - self.x0)
+
+    def height(self) -> float:
+        return max(0.0, self.y1 - self.y0)
+
+    def area(self) -> float:
+        return self.width() * self.height()
+
+
+@dataclass(frozen=True)
+class PageGeometry:
+    """Page dimensions and resolution."""
+
+    page: int
+    width: float
+    height: float
+    dpi: float | None = None
+
+
+@dataclass(frozen=True)
+class PageBox:
+    """A span of geometry on a page."""
+
+    page: int
+    bbox: BoundingBox | None = None
+    polygon: Tuple[Tuple[float, float], ...] | None = None
+
+    def __post_init__(self) -> None:
+        if self.bbox is None and self.polygon is None:
+            raise ValueError("PageBox requires either bbox or polygon")
+
+
+@dataclass
+class Artifact:
+    """Base class for all typed artifacts."""
+
+    id: str
+    doc_id: str
+    parents: Tuple[str, ...] = field(default_factory=tuple)
+    meta: MutableMapping[str, Any] = field(default_factory=dict)
+    provenance: Trace | None = None
+
+    TYPE: ClassVar[str] = "Artifact"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parents", tuple(self.parents))
+
+    @property
+    def type(self) -> str:
+        return self.TYPE
+
+
+@dataclass
+class DocumentSource:
+    mime: str
+    bytes_ref: str | None = None
+    path: str | None = None
+    pages: int | None = None
+
+
+@dataclass
+class Document(Artifact):
+    """Represents an ingested document."""
+
+    TYPE: ClassVar[str] = "Document"
+    source: DocumentSource = field(default_factory=DocumentSource)
+
+
+@dataclass
+class TextToken:
+    i: int
+    start_char: int
+    end_char: int
+    text: str
+    page: int | None = None
+    bbox: BoundingBox | None = None
+
+
+@dataclass
+class TextLayer(Artifact):
+    """Full document text and tokenisation."""
+
+    TYPE: ClassVar[str] = "TextLayer"
+    text: str = ""
+    tokens: List[TextToken] = field(default_factory=list)
+    reading_order: List[int] | None = None
+
+    def token_by_index(self, index: int) -> TextToken:
+        return self.tokens[index]
+
+
+@dataclass
+class LayoutElement:
+    """Layout grouping with optional bounding boxes and token references."""
+
+    id: str
+    bbox: BoundingBox | None = None
+    polygon: Tuple[Tuple[float, float], ...] | None = None
+    token_indices: Tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        self.token_indices = tuple(self.token_indices)
+
+
+@dataclass
+class LayoutLayer(Artifact):
+    """Captures document geometry and grouping."""
+
+    TYPE: ClassVar[str] = "LayoutLayer"
+    pages: List[PageGeometry] = field(default_factory=list)
+    blocks: List[LayoutElement] = field(default_factory=list)
+    lines: List[LayoutElement] = field(default_factory=list)
+    words: List[LayoutElement] = field(default_factory=list)
+    token_map: Dict[int, int] | None = None
+
+
+@dataclass
+class SpanRef(Artifact):
+    """A span linking character offsets to layout geometry."""
+
+    TYPE: ClassVar[str] = "SpanRef"
+    start_char: int = 0
+    end_char: int = 0
+    token_span: Tuple[int, int] = (0, 0)
+    page_boxes: Tuple[PageBox, ...] = ()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.page_boxes = tuple(self.page_boxes)
+
+
+@dataclass
+class EntityMention(Artifact):
+    """Surface mention detected by NER."""
+
+    TYPE: ClassVar[str] = "EntityMention"
+    label: str = ""
+    text: str = ""
+    span: SpanRef | None = None
+    score: float | None = None
+    evidence: Tuple[SpanRef | str | Mapping[str, Any], ...] = ()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.evidence = tuple(self.evidence)
+
+
+@dataclass
+class KVPair(Artifact):
+    """Key-value pair extracted from the document."""
+
+    TYPE: ClassVar[str] = "KVPair"
+    field: str = ""
+    value_span: SpanRef | None = None
+    key_span: SpanRef | None = None
+    normalized_value: Any | None = None
+    score: float | None = None
+
+
+@dataclass
+class RelationArgument:
+    role: str
+    mention_id: str
+
+
+@dataclass
+class Relation(Artifact):
+    """Relation between entity mentions."""
+
+    TYPE: ClassVar[str] = "Relation"
+    type: str = ""
+    args: Tuple[RelationArgument, ...] = ()
+    score: float | None = None
+    evidence: Tuple[SpanRef | str | Mapping[str, Any], ...] = ()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.args = tuple(self.args)
+        self.evidence = tuple(self.evidence)
+
+
+ArtifactLike = Artifact
+ArtifactIterable = Iterable[ArtifactLike]

--- a/ief/exceptions.py
+++ b/ief/exceptions.py
@@ -1,0 +1,16 @@
+"""Custom exception types used by the IE core runtime."""
+
+class SchemaValidationError(ValueError):
+    """Raised when configuration parameters do not match a JSON schema."""
+
+
+class TaskValidationError(RuntimeError):
+    """Raised when a task reports invalid inputs or outputs."""
+
+
+class RegistryError(LookupError):
+    """Raised when a task capability cannot be resolved."""
+
+
+class PipelineError(RuntimeError):
+    """Raised when the pipeline configuration is invalid."""

--- a/ief/pipeline.py
+++ b/ief/pipeline.py
@@ -1,0 +1,234 @@
+"""Pipeline orchestration following the lean-core IE spec."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import re
+from typing import Any, Dict, List, Mapping, MutableMapping, Sequence
+
+from .artifacts import Artifact
+from .exceptions import PipelineError, RegistryError
+from .registry import TaskRegistry
+from .store import ArtifactStore
+from .tasks import RunContext, TaskResult
+
+_EDGE_PATTERN = re.compile(r"^(?P<src>[A-Za-z0-9_\-]+):(?P<atype>[A-Za-z0-9_\-]+)\s*->\s*(?P<dst>[A-Za-z0-9_\-]+)$")
+
+
+@dataclass
+class PipelineNode:
+    id: str
+    uses: str
+    params: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PipelineEdge:
+    source: str
+    artifact_type: str
+    target: str
+
+
+@dataclass
+class PipelineConfig:
+    version: str
+    nodes: List[PipelineNode]
+    edges: List[PipelineEdge]
+    run: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NodeRunRecord:
+    id: str
+    uses: str
+    params: Mapping[str, Any]
+    config_hash: str
+    started_at: datetime
+    ended_at: datetime
+    metrics: Mapping[str, float]
+    model_id: str | None
+    warnings: Sequence[str]
+
+    @property
+    def latency_ms(self) -> float:
+        return (self.ended_at - self.started_at).total_seconds() * 1000.0
+
+
+@dataclass
+class RunManifest:
+    run_id: str
+    seed: int
+    started_at: datetime
+    ended_at: datetime | None = None
+    nodes: MutableMapping[str, NodeRunRecord] = field(default_factory=dict)
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PipelineRunResult:
+    run_id: str
+    artifact_store: ArtifactStore
+    node_results: Mapping[str, TaskResult]
+    manifest: RunManifest
+
+    def get_artifacts(self, artifact_type: str) -> List[Artifact]:
+        return self.artifact_store.get_global(artifact_type)
+
+    @property
+    def metrics(self) -> Dict[str, float]:
+        aggregated: Dict[str, float] = {}
+        for node_id, result in self.node_results.items():
+            for key, value in result.metrics.items():
+                aggregated[f"{node_id}.{key}"] = value
+        return aggregated
+
+
+class Pipeline:
+    def __init__(self, config: PipelineConfig, registry: TaskRegistry) -> None:
+        self.config = config
+        self.registry = registry
+        self._nodes: Dict[str, PipelineNode] = {node.id: node for node in config.nodes}
+        if len(self._nodes) != len(config.nodes):
+            raise PipelineError("Duplicate node identifiers in pipeline configuration")
+        self._edges = list(config.edges)
+        self._incoming: MutableMapping[str, List[PipelineEdge]] = defaultdict(list)
+        self._outgoing: MutableMapping[str, List[PipelineEdge]] = defaultdict(list)
+        for edge in self._edges:
+            if edge.source not in self._nodes:
+                raise PipelineError(f"Edge references unknown source node {edge.source!r}")
+            if edge.target not in self._nodes:
+                raise PipelineError(f"Edge references unknown target node {edge.target!r}")
+            self._incoming[edge.target].append(edge)
+            self._outgoing[edge.source].append(edge)
+        self._order = self._topological_order()
+
+    @classmethod
+    def from_config_dict(cls, raw: Mapping[str, Any], registry: TaskRegistry) -> "Pipeline":
+        try:
+            version = raw["version"]
+            pipeline = raw["pipeline"]
+        except KeyError as exc:
+            raise PipelineError("Configuration must include 'version' and 'pipeline'") from exc
+        nodes = [PipelineNode(id=item["id"], uses=item["uses"], params=item.get("params", {})) for item in pipeline.get("nodes", [])]
+        edges = [cls._parse_edge(item) for item in pipeline.get("edges", [])]
+        run_cfg = raw.get("run", {})
+        cfg = PipelineConfig(version=version, nodes=nodes, edges=edges, run=run_cfg)
+        return cls(cfg, registry)
+
+    @staticmethod
+    def _parse_edge(raw: Any) -> PipelineEdge:
+        if isinstance(raw, Mapping):
+            return PipelineEdge(source=raw["source"], artifact_type=raw["artifact_type"], target=raw["target"])
+        if isinstance(raw, str):
+            match = _EDGE_PATTERN.match(raw.strip())
+            if not match:
+                raise PipelineError(f"Invalid edge specification: {raw!r}")
+            return PipelineEdge(
+                source=match.group("src"),
+                artifact_type=match.group("atype"),
+                target=match.group("dst"),
+            )
+        raise PipelineError(f"Unsupported edge specification: {raw!r}")
+
+    def _topological_order(self) -> List[str]:
+        indegree: MutableMapping[str, int] = {node_id: 0 for node_id in self._nodes}
+        for edge in self._edges:
+            indegree[edge.target] += 1
+        queue = deque([node_id for node_id, deg in indegree.items() if deg == 0])
+        order: List[str] = []
+        while queue:
+            node = queue.popleft()
+            order.append(node)
+            for edge in self._outgoing.get(node, ()):  # type: ignore[arg-type]
+                indegree[edge.target] -= 1
+                if indegree[edge.target] == 0:
+                    queue.append(edge.target)
+        if len(order) != len(self._nodes):
+            raise PipelineError("Pipeline contains a cycle")
+        return order
+
+    def run(
+        self,
+        initial_artifacts: Sequence[Artifact] | Mapping[str, Sequence[Artifact]] | None = None,
+        *,
+        seed: int | None = None,
+        params_override: Mapping[str, Mapping[str, Any]] | None = None,
+        extras: Mapping[str, Any] | None = None,
+    ) -> PipelineRunResult:
+        store = ArtifactStore()
+        if initial_artifacts:
+            if isinstance(initial_artifacts, Mapping):
+                for artifacts in initial_artifacts.values():
+                    store.add_many(artifacts, producer_id=None)
+            else:
+                store.add_many(initial_artifacts, producer_id=None)
+        base_seed = seed if seed is not None else int(datetime.now(timezone.utc).timestamp())
+        run_id = hashlib.sha1(f"{base_seed}-{datetime.now(timezone.utc).isoformat()}".encode()).hexdigest()
+        manifest = RunManifest(run_id=run_id, seed=base_seed, started_at=datetime.now(timezone.utc))
+        if extras:
+            manifest.extras.update(dict(extras))
+        results: Dict[str, TaskResult] = {}
+        params_override = params_override or {}
+
+        for idx, node_id in enumerate(self._order):
+            node = self._nodes[node_id]
+            if node.uses not in self.registry:
+                raise RegistryError(f"Capability {node.uses!r} not registered")
+            task = self.registry.create(node.uses)
+            node_params_raw = dict(node.params)
+            node_params_raw.update(params_override.get(node_id, {}))
+            node_params = task.validate_params(node_params_raw)
+            ctx = RunContext(
+                run_id=run_id,
+                node_id=node_id,
+                capability=node.uses,
+                seed=base_seed + idx,
+                store=store,
+                extras=extras,
+            )
+            ctx.started_at = datetime.now(timezone.utc)
+            inputs: Dict[str, List[Artifact]] = {}
+            incoming_edges = self._incoming.get(node_id, [])
+            if incoming_edges:
+                for edge in incoming_edges:
+                    inputs.setdefault(edge.artifact_type, []).extend(
+                        store.get_from(edge.source, edge.artifact_type)
+                    )
+            else:
+                for artifact_type in task.input_types:
+                    inputs.setdefault(artifact_type, []).extend(store.get_global(artifact_type))
+            for artifact_type in task.input_types:
+                inputs.setdefault(artifact_type, [])
+            frozen_inputs = {key: tuple(values) for key, values in inputs.items()}
+            result = task.run(inputs=frozen_inputs, params=node_params, ctx=ctx)
+            if not isinstance(result, TaskResult):
+                raise PipelineError(f"Task {node.uses} returned invalid result type {type(result)!r}")
+            result.trace = task.make_trace(ctx, node_params, frozen_inputs, result)
+            allowed_outputs = set(task.output_types) if task.output_types else None
+            if allowed_outputs:
+                for artifact in result.artifacts:
+                    if artifact.type not in allowed_outputs:
+                        raise PipelineError(
+                            f"Task {node.uses} produced unexpected artifact type {artifact.type!r}"
+                        )
+            for artifact in result.artifacts:
+                if artifact.provenance is None:
+                    artifact.provenance = result.trace
+                store.add(artifact, producer_id=node_id)
+            results[node_id] = result
+            manifest.nodes[node_id] = NodeRunRecord(
+                id=node_id,
+                uses=node.uses,
+                params=dict(node_params),
+                config_hash=result.trace.config_hash,
+                started_at=result.trace.started_at,
+                ended_at=result.trace.ended_at,
+                metrics=dict(result.metrics),
+                model_id=result.trace.model_id,
+                warnings=list(result.trace.warnings),
+            )
+        manifest.ended_at = datetime.now(timezone.utc)
+        return PipelineRunResult(run_id=run_id, artifact_store=store, node_results=results, manifest=manifest)

--- a/ief/registry.py
+++ b/ief/registry.py
@@ -1,0 +1,54 @@
+"""Task registry allowing capability-based lookup."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Callable, Iterable, MutableMapping
+
+from .exceptions import RegistryError
+from .tasks import Task
+
+TaskFactory = Callable[[], Task]
+
+
+class TaskRegistry:
+    """Map string capabilities to task factories."""
+
+    def __init__(self) -> None:
+        self._factories: MutableMapping[str, TaskFactory] = {}
+
+    def register(self, capability: str, factory: TaskFactory | type[Task]) -> None:
+        if capability in self._factories:
+            raise RegistryError(f"Capability {capability!r} already registered")
+        if inspect.isclass(factory):
+            if not issubclass(factory, Task):  # type: ignore[arg-type]
+                raise RegistryError("Factory class must inherit from Task")
+            self._factories[capability] = factory  # type: ignore[assignment]
+        else:
+            self._factories[capability] = factory  # type: ignore[assignment]
+
+    def register_task(self, capability: str) -> Callable[[TaskFactory | type[Task]], TaskFactory | type[Task]]:
+        def decorator(factory: TaskFactory | type[Task]) -> TaskFactory | type[Task]:
+            self.register(capability, factory)
+            return factory
+
+        return decorator
+
+    def create(self, capability: str) -> Task:
+        try:
+            factory = self._factories[capability]
+        except KeyError as exc:
+            raise RegistryError(f"Unknown capability {capability!r}") from exc
+        if inspect.isclass(factory):
+            task = factory()  # type: ignore[call-arg]
+        else:
+            task = factory()
+        if not getattr(task, "id", None):
+            task.id = capability
+        return task
+
+    def __contains__(self, capability: str) -> bool:
+        return capability in self._factories
+
+    def capabilities(self) -> Iterable[str]:
+        return self._factories.keys()

--- a/ief/schema.py
+++ b/ief/schema.py
@@ -1,0 +1,153 @@
+"""Light-weight JSON schema validation tailored to the task parameter use-case."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Dict
+
+from .exceptions import SchemaValidationError
+
+_JSON_TYPE_TO_PY = {
+    "string": str,
+    "number": (int, float),
+    "integer": int,
+    "boolean": bool,
+    "object": Mapping,
+    "array": Sequence,
+    "null": type(None),
+}
+
+
+def _ensure_number(value: Any, schema_type: str, path: str) -> None:
+    if schema_type == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise SchemaValidationError(f"Expected number at {path!r}, got {type(value).__name__}")
+    elif schema_type == "integer":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise SchemaValidationError(f"Expected integer at {path!r}, got {type(value).__name__}")
+
+
+def _assert_type(value: Any, schema_type: str | Sequence[str], path: str) -> None:
+    if isinstance(schema_type, str):
+        expected = _JSON_TYPE_TO_PY.get(schema_type)
+        if expected is None:
+            raise SchemaValidationError(f"Unsupported schema type {schema_type!r} at {path!r}")
+        if schema_type in {"number", "integer"}:
+            _ensure_number(value, schema_type, path)
+            return
+        if not isinstance(value, expected):
+            raise SchemaValidationError(
+                f"Expected {schema_type} at {path!r}, got {type(value).__name__}"
+            )
+    else:
+        for option in schema_type:
+            try:
+                _assert_type(value, option, path)
+                return
+            except SchemaValidationError:
+                continue
+        raise SchemaValidationError(
+            f"Value at {path!r} does not match any allowed type {list(schema_type)!r}"
+        )
+
+
+def _apply_common_checks(schema: Mapping[str, Any], value: Any, path: str) -> None:
+    if "enum" in schema and value not in schema["enum"]:
+        raise SchemaValidationError(
+            f"Value {value!r} at {path!r} not in enumeration {schema['enum']!r}"
+        )
+    if "const" in schema and value != schema["const"]:
+        raise SchemaValidationError(
+            f"Value {value!r} at {path!r} does not equal required constant {schema['const']!r}"
+        )
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        maximum = schema.get("maximum")
+        exclusive_minimum = schema.get("exclusiveMinimum")
+        exclusive_maximum = schema.get("exclusiveMaximum")
+        if minimum is not None and value < minimum:
+            raise SchemaValidationError(f"Value {value!r} at {path!r} below minimum {minimum!r}")
+        if maximum is not None and value > maximum:
+            raise SchemaValidationError(f"Value {value!r} at {path!r} above maximum {maximum!r}")
+        if exclusive_minimum is not None and value <= exclusive_minimum:
+            raise SchemaValidationError(
+                f"Value {value!r} at {path!r} not greater than {exclusive_minimum!r}"
+            )
+        if exclusive_maximum is not None and value >= exclusive_maximum:
+            raise SchemaValidationError(
+                f"Value {value!r} at {path!r} not less than {exclusive_maximum!r}"
+            )
+
+
+def _join(path: str, key: str) -> str:
+    return f"{path}.{key}" if path else key
+
+
+def _apply_schema(schema: Mapping[str, Any], value: Any, path: str) -> Any:
+    schema_type = schema.get("type")
+    if schema_type is not None:
+        _assert_type(value, schema_type, path)
+    _apply_common_checks(schema, value, path)
+
+    if schema_type == "object" or (schema_type is None and isinstance(value, Mapping)):
+        return _validate_object(schema, value, path)
+    if schema_type == "array" or (schema_type is None and isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))):
+        return _validate_array(schema, value, path)
+    return value
+
+
+def _validate_object(schema: Mapping[str, Any], value: Mapping[str, Any], path: str) -> Dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"Expected object at {path!r}")
+    properties = schema.get("properties", {})
+    required = set(schema.get("required", ()))
+    additional = schema.get("additionalProperties", True)
+    result: Dict[str, Any] = {}
+
+    for key, prop_schema in properties.items():
+        if key not in value and "default" in prop_schema:
+            result[key] = prop_schema["default"]
+
+    for key in required:
+        if key not in value and key not in result:
+            raise SchemaValidationError(f"Missing required property {key!r} at {path!r}")
+
+    for key, child_value in value.items():
+        if key in properties:
+            result[key] = _apply_schema(properties[key], child_value, _join(path, key))
+        else:
+            if isinstance(additional, Mapping):
+                result[key] = _apply_schema(additional, child_value, _join(path, key))
+            elif additional is False:
+                raise SchemaValidationError(f"Unexpected property {key!r} at {path!r}")
+            else:
+                result[key] = child_value
+    return result
+
+
+def _validate_array(schema: Mapping[str, Any], value: Sequence[Any], path: str) -> list[Any]:
+    if isinstance(value, (str, bytes, bytearray)):
+        raise SchemaValidationError(f"Expected array at {path!r}")
+    result = list(value)
+    items_schema = schema.get("items")
+    min_items = schema.get("minItems")
+    max_items = schema.get("maxItems")
+    if min_items is not None and len(result) < min_items:
+        raise SchemaValidationError(f"Array at {path!r} shorter than {min_items}")
+    if max_items is not None and len(result) > max_items:
+        raise SchemaValidationError(f"Array at {path!r} longer than {max_items}")
+    if isinstance(items_schema, Mapping):
+        for idx, item in enumerate(result):
+            result[idx] = _apply_schema(items_schema, item, f"{path}[{idx}]")
+    return result
+
+
+def validate_params(params: Mapping[str, Any] | None, schema: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Validate ``params`` against ``schema`` and return a normalised copy."""
+
+    params = params or {}
+    if not isinstance(params, Mapping):
+        raise SchemaValidationError("Task params must be a mapping")
+    if not schema:
+        return dict(params)
+    return _apply_schema(schema, params, path="")

--- a/ief/store.py
+++ b/ief/store.py
@@ -1,0 +1,49 @@
+"""Storage helpers for managing artifacts during a pipeline run."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, MutableMapping
+
+from .artifacts import Artifact
+
+_INITIAL_PRODUCER = "__initial__"
+
+
+@dataclass
+class ArtifactRecord:
+    artifact: Artifact
+    producer_id: str
+
+
+class ArtifactStore:
+    """Keep track of artifacts by type and producing node."""
+
+    def __init__(self, artifacts: Iterable[Artifact] | None = None) -> None:
+        self._by_type: MutableMapping[str, List[Artifact]] = defaultdict(list)
+        self._by_node: MutableMapping[tuple[str | None, str], List[Artifact]] = defaultdict(list)
+        if artifacts:
+            self.add_many(artifacts, producer_id=None)
+
+    def add_many(self, artifacts: Iterable[Artifact], producer_id: str | None) -> None:
+        for artifact in artifacts:
+            self.add(artifact, producer_id)
+
+    def add(self, artifact: Artifact, producer_id: str | None) -> None:
+        key = (producer_id or _INITIAL_PRODUCER, artifact.type)
+        self._by_type[artifact.type].append(artifact)
+        self._by_node[key].append(artifact)
+
+    def get_global(self, artifact_type: str) -> List[Artifact]:
+        return list(self._by_type.get(artifact_type, ()))
+
+    def get_from(self, producer_id: str | None, artifact_type: str) -> List[Artifact]:
+        key = (producer_id or _INITIAL_PRODUCER, artifact_type)
+        return list(self._by_node.get(key, ()))
+
+    def snapshot(self) -> Dict[str, List[Artifact]]:
+        return {atype: list(items) for atype, items in self._by_type.items()}
+
+    def __contains__(self, artifact_type: str) -> bool:
+        return artifact_type in self._by_type

--- a/ief/tasks.py
+++ b/ief/tasks.py
@@ -1,0 +1,130 @@
+"""Task base classes and runtime utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+import random
+from typing import Any, Dict, Mapping, Sequence
+
+from .artifacts import Artifact
+from .exceptions import SchemaValidationError
+from .schema import validate_params
+from .trace import Trace
+from .store import ArtifactStore
+
+
+@dataclass
+class TaskResult:
+    """Standard return value from a task run."""
+
+    artifacts: Sequence[Artifact]
+    trace: Trace | None = None
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.artifacts = tuple(self.artifacts)
+        self.metrics = dict(self.metrics)
+
+
+class RunContext:
+    """Runtime information available to tasks."""
+
+    def __init__(
+        self,
+        run_id: str,
+        node_id: str,
+        capability: str,
+        seed: int,
+        store: ArtifactStore,
+        extras: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.run_id = run_id
+        self.node_id = node_id
+        self.capability = capability
+        self.seed = seed
+        self.random = random.Random(seed)
+        self._store = store
+        self._features: Dict[str, Any] = {}
+        self._warnings: list[str] = []
+        self.extras = dict(extras or {})
+        self.started_at = datetime.now(timezone.utc)
+
+    def record_feature(self, key: str, value: Any) -> None:
+        self._features[key] = value
+
+    def warn(self, message: str) -> None:
+        self._warnings.append(message)
+
+    def get_features(self) -> Dict[str, Any]:
+        return dict(self._features)
+
+    def get_warnings(self) -> tuple[str, ...]:
+        return tuple(self._warnings)
+
+    def get_artifacts(self, artifact_type: str) -> Sequence[Artifact]:
+        return tuple(self._store.get_global(artifact_type))
+
+    def get_artifacts_from(self, producer_id: str | None, artifact_type: str) -> Sequence[Artifact]:
+        return tuple(self._store.get_from(producer_id, artifact_type))
+
+
+class Task:
+    """Base class for concrete pipeline tasks."""
+
+    id: str
+    input_types: Sequence[str] = ()
+    output_types: Sequence[str] = ()
+    params_schema: Mapping[str, Any] | None = {"type": "object", "properties": {}, "additionalProperties": True}
+    default_model_id: str | None = None
+
+    def validate_params(self, params: Mapping[str, Any] | None) -> Dict[str, Any]:
+        try:
+            return validate_params(params, self.params_schema)
+        except SchemaValidationError as exc:
+            raise SchemaValidationError(f"Invalid parameters for task {self.id}: {exc}") from exc
+
+    def config_hash(self, params: Mapping[str, Any]) -> str:
+        normalised = json.dumps(params, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+    def run(
+        self,
+        inputs: Mapping[str, Sequence[Artifact]],
+        params: Mapping[str, Any],
+        ctx: RunContext,
+    ) -> TaskResult:
+        raise NotImplementedError
+
+    def make_trace(
+        self,
+        ctx: RunContext,
+        params: Mapping[str, Any],
+        inputs: Mapping[str, Sequence[Artifact]],
+        result: TaskResult,
+    ) -> Trace:
+        config_hash = self.config_hash(params)
+        parent_ids = tuple(artifact.id for artifacts in inputs.values() for artifact in artifacts)
+        finished_at = datetime.now(timezone.utc)
+        started_at = getattr(result.trace, "started_at", ctx.started_at)
+        features = ctx.get_features()
+        warnings = list(ctx.get_warnings())
+        extra: Dict[str, Any] = {}
+        if result.trace is not None:
+            features.update(result.trace.features)
+            warnings.extend(result.trace.warnings)
+            extra.update(result.trace.extra)
+        return Trace(
+            run_id=ctx.run_id,
+            task_id=ctx.node_id,
+            model_id=self.default_model_id,
+            config_hash=config_hash,
+            started_at=started_at,
+            ended_at=finished_at,
+            parents=parent_ids,
+            features=features,
+            warnings=tuple(warnings),
+            extra=extra,
+        )

--- a/ief/trace.py
+++ b/ief/trace.py
@@ -1,0 +1,82 @@
+"""Trace data structures capturing provenance for each task invocation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Tuple
+
+
+@dataclass
+class Trace:
+    """Execution metadata attached to artifacts produced by a task."""
+
+    run_id: str
+    task_id: str
+    model_id: str | None
+    config_hash: str
+    started_at: datetime
+    ended_at: datetime
+    parents: Tuple[str, ...] = field(default_factory=tuple)
+    features: Dict[str, Any] = field(default_factory=dict)
+    warnings: Tuple[str, ...] = field(default_factory=tuple)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def duration_ms(self) -> float:
+        """Return the duration in milliseconds."""
+
+        return (self.ended_at - self.started_at).total_seconds() * 1000.0
+
+    @property
+    def time(self) -> Mapping[str, datetime]:
+        """Return a dictionary matching the spec ``time`` field."""
+
+        return {"start": self.started_at, "end": self.ended_at}
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Serialise the trace into a JSON-serialisable dictionary."""
+
+        return {
+            "run_id": self.run_id,
+            "task_id": self.task_id,
+            "model_id": self.model_id,
+            "config_hash": self.config_hash,
+            "time": {
+                "start": self.started_at.isoformat(),
+                "end": self.ended_at.isoformat(),
+            },
+            "parents": list(self.parents),
+            "features": dict(self.features),
+            "warnings": list(self.warnings),
+            "extra": dict(self.extra),
+        }
+
+    @classmethod
+    def now(
+        cls,
+        run_id: str,
+        task_id: str,
+        model_id: str | None,
+        config_hash: str,
+        parents: Tuple[str, ...] = (),
+        features: Mapping[str, Any] | None = None,
+        warnings: Tuple[str, ...] | None = None,
+        extra: Mapping[str, Any] | None = None,
+    ) -> "Trace":
+        """Convenience constructor capturing the current time."""
+
+        started = datetime.now(timezone.utc)
+        ended = datetime.now(timezone.utc)
+        return cls(
+            run_id=run_id,
+            task_id=task_id,
+            model_id=model_id,
+            config_hash=config_hash,
+            started_at=started,
+            ended_at=ended,
+            parents=tuple(parents),
+            features=dict(features or {}),
+            warnings=tuple(warnings or ()),
+            extra=dict(extra or {}),
+        )


### PR DESCRIPTION
## Summary
- add typed artifact data structures and provenance support for the IE spec
- implement task runtime utilities with schema validation and registry-backed pipeline orchestration
- update the README with usage guidance for the new runtime package

## Testing
- python -m compileall ief
- python - <<'PY'
from ief import (
    Document,
    DocumentSource,
    EntityMention,
    Pipeline,
    Task,
    TaskRegistry,
    TaskResult,
    TextLayer,
    SpanRef,
)
from ief.tasks import RunContext
from ief.artifacts import TextToken

registry = TaskRegistry()

class MockIngest(Task):
    id = "ie.ingest"
    input_types = ("Document",)
    output_types = ("TextLayer",)
    params_schema = {"type": "object", "properties": {}}

    def run(self, inputs, params, ctx):
        doc = inputs.get("Document", ())[0]
        text = "hello world"
        tokens = [TextToken(i=0, start_char=0, end_char=5, text="hello"), TextToken(i=1, start_char=6, end_char=11, text="world")]
        layer = TextLayer(id="text1", doc_id=doc.id, text=text, tokens=tokens)
        return TaskResult([layer], metrics={"token_count": len(tokens)})

registry.register("ie.ingest.text/mock", lambda: MockIngest())

class MockNER(Task):
    id = "ie.ner"
    input_types = ("TextLayer",)
    output_types = ("EntityMention",)
    params_schema = {"type": "object", "properties": {}}

    def run(self, inputs, params, ctx):
        text_layer = inputs["TextLayer"][0]
        span = SpanRef(id="span1", doc_id=text_layer.doc_id, start_char=0, end_char=5, token_span=(0,1))
        mention = EntityMention(id="ent1", doc_id=text_layer.doc_id, label="WORD", text="hello", span=span)
        return TaskResult([mention], metrics={"mentions": 1})

registry.register("ie.ner/mock", lambda: MockNER())

config = {
    "version": "0.1",
    "pipeline": {
        "nodes": [
            {"id": "ingest", "uses": "ie.ingest.text/mock"},
            {"id": "ner", "uses": "ie.ner/mock"},
        ],
        "edges": [
            "ingest:TextLayer -> ner",
        ],
    },
}

pipeline = Pipeline.from_config_dict(config, registry)
doc = Document(id="doc1", doc_id="doc1", source=DocumentSource(mime="text/plain"))
run = pipeline.run(initial_artifacts={"Document": [doc]})
print(sorted(run.metrics))
print([a.id for a in run.get_artifacts("EntityMention")])
PY

------
https://chatgpt.com/codex/tasks/task_e_68cfba9956b08325b23bea3f5db4c8c7